### PR TITLE
Improve login flow for Google OAuth

### DIFF
--- a/garden-ai/lib/authOptions.ts
+++ b/garden-ai/lib/authOptions.ts
@@ -12,6 +12,8 @@ export const authOptions: AuthOptions = {
         GoogleProvider({
             clientId: process.env.GOOGLE_ID!,
             clientSecret: process.env.GOOGLE_SECRET!,
+            // Allow accounts with the same email to be linked across providers
+            allowDangerousEmailAccountLinking: true,
         })
     ],
     secret: process.env.NEXTAUTH_SECRET,
@@ -19,6 +21,40 @@ export const authOptions: AuthOptions = {
         strategy: "database",
     },
     callbacks: {
+        // Link accounts by email to avoid "AccountNotLinked" errors
+        async signIn({ user, account }) {
+            if (account?.provider === 'google' && user.email) {
+                const existing = await prisma.user.findUnique({
+                    where: { email: user.email },
+                });
+                if (existing && existing.id !== user.id) {
+                    await prisma.account.upsert({
+                        where: {
+                            provider_providerAccountId: {
+                                provider: account.provider,
+                                providerAccountId: account.providerAccountId,
+                            },
+                        },
+                        update: {},
+                        create: {
+                            userId: existing.id,
+                            type: account.type,
+                            provider: account.provider,
+                            providerAccountId: account.providerAccountId,
+                            access_token: account.access_token,
+                            expires_at: account.expires_at,
+                            id_token: account.id_token,
+                            refresh_token: account.refresh_token,
+                            scope: account.scope,
+                            session_state: account.session_state,
+                            token_type: account.token_type,
+                        },
+                    });
+                    return true;
+                }
+            }
+            return true;
+        },
         // Your session and redirect callbacks
         async session({ session, user }) {
             if (session?.user && user?.id) {
@@ -33,7 +69,6 @@ export const authOptions: AuthOptions = {
         async redirect({ url, baseUrl }) {
             return `${baseUrl}/ask`;
         }
-        // Add signIn callback here if you revert to pre-signup flow later
     },
     pages: {
         error: '/auth/error',

--- a/garden-ai/src/app/auth/error/page.tsx
+++ b/garden-ai/src/app/auth/error/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { Suspense } from 'react';
+
+function ErrorContent() {
+  const params = useSearchParams();
+  const error = params.get('error');
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24">
+      <h1 className="text-2xl font-semibold mb-4">Authentication Error</h1>
+      <p className="mb-6 text-red-600">{error || 'Unable to sign in. Please try again.'}</p>
+      <Link href="/" className="text-green-700 underline">Go back home</Link>
+    </div>
+  );
+}
+
+export default function AuthErrorPage() {
+  return (
+    <Suspense>
+      <ErrorContent />
+    </Suspense>
+  );
+}

--- a/garden-ai/src/app/page.tsx
+++ b/garden-ai/src/app/page.tsx
@@ -49,7 +49,12 @@ export default function HomePage() {
       return;
     }
     if (status === 'unauthenticated') {
-      signIn('google', { callbackUrl: '/ask' });
+      const res = await signIn('google', { callbackUrl: '/ask', redirect: false });
+      if (res?.url) {
+        router.push(res.url);
+      } else if (res?.error) {
+        router.push(`/auth/error?error=${encodeURIComponent(res.error)}`);
+      }
       return;
     }
     if (status === 'authenticated') {

--- a/garden-ai/src/app/pricing/page.tsx
+++ b/garden-ai/src/app/pricing/page.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from 'react';
 import { useSession, signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import { loadStripe, Stripe } from '@stripe/stripe-js';
 import Header from '@/components/Header'; // Adjust path if needed
 import Head from 'next/head';
@@ -24,6 +25,7 @@ export default function PricingPage() {
     const [isLoading, setIsLoading] = useState<string | null>(null); // Store Price ID of loading button
     const [error, setError] = useState<string | null>(null);
     const { data: session, status } = useSession();
+    const router = useRouter();
 
     // Get Price IDs from environment variables
     // Ensure these are prefixed with NEXT_PUBLIC_ in your .env.local
@@ -38,7 +40,12 @@ export default function PricingPage() {
 
     const handleSubscription = async (priceId: string, isTrial: boolean = false) => {
         if (status === 'unauthenticated') {
-            signIn('google', { callbackUrl: '/pricing' }); // Redirect to sign-in, then back to pricing
+            const res = await signIn('google', { callbackUrl: '/pricing', redirect: false });
+            if (res?.url) {
+                router.push(res.url);
+            } else if (res?.error) {
+                router.push(`/auth/error?error=${encodeURIComponent(res.error)}`);
+            }
             return;
         }
         if (status === 'loading' || !session?.user) {

--- a/garden-ai/src/components/Header.jsx
+++ b/garden-ai/src/components/Header.jsx
@@ -7,10 +7,16 @@ import Image from 'next/image';
 
 export default function Header() {
   const { data: session, status } = useSession();
+  const router = useRouter();
 
-  const handleSignIn = () => {
-    // Standard sign-in, redirect to /ask on success
-    signIn('google', { callbackUrl: '/ask' });
+  const handleSignIn = async () => {
+    // Manually handle redirect so we can catch errors
+    const res = await signIn('google', { callbackUrl: '/ask', redirect: false });
+    if (res?.error) {
+      router.push(`/auth/error?error=${encodeURIComponent(res.error)}`);
+    } else if (res?.url) {
+      router.push(res.url);
+    }
   };
 
   const handleSignOut = async () => {


### PR DESCRIPTION
## Summary
- link Google logins to existing accounts using a `signIn` callback
- create `/auth/error` page to show sign-in failures
- handle login redirects in Header, homepage and pricing page
- wrap the auth error page in a `Suspense` boundary

## Testing
- `npm run lint`



------
https://chatgpt.com/codex/tasks/task_e_68823a780db8833098474ce94a1eedaf