### PR TITLE
Switch login to built‑in email auth

### DIFF
--- a/garden-ai/lib/authOptions.ts
+++ b/garden-ai/lib/authOptions.ts
@@ -1,18 +1,18 @@
-// src/lib/authOptions.ts  <- NEW FILE
+// src/lib/authOptions.ts
 
 import { AuthOptions } from 'next-auth'; // Import base type
 import { PrismaAdapter } from '@next-auth/prisma-adapter';
-import GoogleProvider from 'next-auth/providers/google';
+import EmailProvider from 'next-auth/providers/email';
 import prisma from './prisma'; // Adjust path to your prisma client instance
 
 // Export the options so they can be imported elsewhere
 export const authOptions: AuthOptions = {
     adapter: PrismaAdapter(prisma),
     providers: [
-        GoogleProvider({
-            clientId: process.env.GOOGLE_ID!,
-            clientSecret: process.env.GOOGLE_SECRET!,
-        })
+        EmailProvider({
+            server: process.env.EMAIL_SERVER!,
+            from: process.env.EMAIL_FROM!,
+        }),
     ],
     secret: process.env.NEXTAUTH_SECRET,
     session: {
@@ -33,7 +33,6 @@ export const authOptions: AuthOptions = {
         async redirect({ url, baseUrl }) {
             return `${baseUrl}/ask`;
         }
-        // Add signIn callback here if you revert to pre-signup flow later
     },
     pages: {
         error: '/auth/error',

--- a/garden-ai/src/app/auth/error/page.tsx
+++ b/garden-ai/src/app/auth/error/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { Suspense } from 'react';
+
+function ErrorContent() {
+  const params = useSearchParams();
+  const error = params.get('error');
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24">
+      <h1 className="text-2xl font-semibold mb-4">Authentication Error</h1>
+      <p className="mb-6 text-red-600">{error || 'Unable to sign in. Please try again.'}</p>
+      <Link href="/" className="text-green-700 underline">Go back home</Link>
+    </div>
+  );
+}
+
+export default function AuthErrorPage() {
+  return (
+    <Suspense>
+      <ErrorContent />
+    </Suspense>
+  );
+}

--- a/garden-ai/src/app/page.tsx
+++ b/garden-ai/src/app/page.tsx
@@ -49,7 +49,12 @@ export default function HomePage() {
       return;
     }
     if (status === 'unauthenticated') {
-      signIn('google', { callbackUrl: '/ask' });
+      const res = await signIn(undefined, { callbackUrl: '/ask', redirect: false });
+      if (res?.url) {
+        router.push(res.url);
+      } else if (res?.error) {
+        router.push(`/auth/error?error=${encodeURIComponent(res.error)}`);
+      }
       return;
     }
     if (status === 'authenticated') {
@@ -272,7 +277,7 @@ export default function HomePage() {
                     Get Started in 3 Easy Steps
                 </h2>
                  <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-left md:text-center max-w-4xl mx-auto">
-                     <div className="p-6 bg-white rounded-lg shadow hover:shadow-2xl hover:scale-105 hover:bg-gray-50 transition-transform transition-shadow duration-300 ease-out"><span className="text-3xl font-bold text-green-500 block mb-2">1</span><h4 className="font-semibold text-lg mb-1 text-gray-700">Sign Up / Log In</h4><p className="text-sm text-gray-600">Create your account or log in instantly using Google.</p></div>
+                     <div className="p-6 bg-white rounded-lg shadow hover:shadow-2xl hover:scale-105 hover:bg-gray-50 transition-transform transition-shadow duration-300 ease-out"><span className="text-3xl font-bold text-green-500 block mb-2">1</span><h4 className="font-semibold text-lg mb-1 text-gray-700">Sign Up / Log In</h4><p className="text-sm text-gray-600">Create your account or log in instantly with your email.</p></div>
                       <div className="p-6 bg-white rounded-lg shadow hover:shadow-2xl hover:scale-105 hover:bg-gray-50 transition-transform transition-shadow duration-300 ease-out"><span className="text-3xl font-bold text-green-500 block mb-2">2</span><h4 className="font-semibold text-lg mb-1 text-gray-700">Subscribe</h4><p className="text-sm text-gray-600">Choose a plan to unlock full access to the AI assistant features.</p></div>
                       <div className="p-6 bg-white rounded-lg shadow hover:shadow-2xl hover:scale-105 hover:bg-gray-50 transition-transform transition-shadow duration-300 ease-out"><span className="text-3xl font-bold text-green-500 block mb-2">3</span><h4 className="font-semibold text-lg mb-1 text-gray-700">Ask Anything!</h4><p className="text-sm text-gray-600">Start chatting with the AI and get expert gardening advice instantly.</p></div>
                  </div>
@@ -313,3 +318,4 @@ export default function HomePage() {
     </>
   );
 }
+

--- a/garden-ai/src/app/pricing/page.tsx
+++ b/garden-ai/src/app/pricing/page.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from 'react';
 import { useSession, signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import { loadStripe, Stripe } from '@stripe/stripe-js';
 import Header from '@/components/Header'; // Adjust path if needed
 import Head from 'next/head';
@@ -24,6 +25,7 @@ export default function PricingPage() {
     const [isLoading, setIsLoading] = useState<string | null>(null); // Store Price ID of loading button
     const [error, setError] = useState<string | null>(null);
     const { data: session, status } = useSession();
+    const router = useRouter();
 
     // Get Price IDs from environment variables
     // Ensure these are prefixed with NEXT_PUBLIC_ in your .env.local
@@ -38,7 +40,12 @@ export default function PricingPage() {
 
     const handleSubscription = async (priceId: string, isTrial: boolean = false) => {
         if (status === 'unauthenticated') {
-            signIn('google', { callbackUrl: '/pricing' }); // Redirect to sign-in, then back to pricing
+            const res = await signIn(undefined, { callbackUrl: '/pricing', redirect: false });
+            if (res?.url) {
+                router.push(res.url);
+            } else if (res?.error) {
+                router.push(`/auth/error?error=${encodeURIComponent(res.error)}`);
+            }
             return;
         }
         if (status === 'loading' || !session?.user) {
@@ -238,3 +245,4 @@ export default function PricingPage() {
 // const TestimonialsSection = () => <section>...</section>;
 // const BlogTeaserSection = () => <section>...</section>;
 // const WhyGardenAISection = () => <section>...</section>;
+

--- a/garden-ai/src/components/Header.jsx
+++ b/garden-ai/src/components/Header.jsx
@@ -7,10 +7,16 @@ import Image from 'next/image';
 
 export default function Header() {
   const { data: session, status } = useSession();
+  const router = useRouter();
 
-  const handleSignIn = () => {
-    // Standard sign-in, redirect to /ask on success
-    signIn('google', { callbackUrl: '/ask' });
+  const handleSignIn = async () => {
+    // Manually handle redirect so we can catch errors
+    const res = await signIn(undefined, { callbackUrl: '/ask', redirect: false });
+    if (res?.error) {
+      router.push(`/auth/error?error=${encodeURIComponent(res.error)}`);
+    } else if (res?.url) {
+      router.push(res.url);
+    }
   };
 
   const handleSignOut = async () => {
@@ -89,3 +95,4 @@ export default function Header() {
     </header>
   )
 }
+


### PR DESCRIPTION
## Summary
- drop Google provider and use `EmailProvider`
- trigger `signIn()` with built-in page instead of Google
- update onboarding copy

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68823a780db8833098474ce94a1eedaf